### PR TITLE
fix api naming

### DIFF
--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 
 int main()
 {
-    raupu_init();
+    ruapu_init();
 
 #define PRINT_ISA_SUPPORT(isa) fprintf(stderr, "%s = %d\n", #isa, ruapu_supports(#isa));
 

--- a/ruapu.h
+++ b/ruapu.h
@@ -7,7 +7,7 @@
 #ifndef RUAPU_H
 #define RUAPU_H
 
-void raupu_init();
+void ruapu_init();
 
 int ruapu_supports(const char* isa);
 
@@ -242,7 +242,7 @@ RUAPU_ISAENTRY(vfpv4)
 
 #undef RUAPU_ISAENTRY
 
-void raupu_init()
+void ruapu_init()
 {
     for (size_t i = 0; i < sizeof(g_ruapu_isa_map) / sizeof(g_ruapu_isa_map[0]); i++)
     {


### PR DESCRIPTION
I guess there is a mis-spelled word in the API function. 