### PR TITLE
loongarch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ _`fma4` on zen1, ISA in hypervisor, etc._
 |mips|`msa`|
 |powerpc|`vsx`|
 |s390x|`zvector`|
-|loongarch||
+|loongarch|`lsx` `lasx`|
 |risc-v|`i` `m` `a` `f` `d` `c`|
 
 ## Techniques inside ruapu

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Detect CPU ISA features with single-file
 
 <table>
-<tr><td>CPU</td><td>&#9989; x86, x86-64<br/>&#9989; arm, aarch64<br/>&#9989; mips<br/>&#9989; powerpc<br/>&#9989; s390x<br/>&#9989; risc-v</td><td rowspan=3>
+<tr><td>CPU</td><td>&#9989; x86, x86-64<br/>&#9989; arm, aarch64<br/>&#9989; mips<br/>&#9989; powerpc<br/>&#9989; s390x<br/>&#9989; risc-v<br/>&#9989; loongarch</td><td rowspan=3>
   
 ```c
 #define RUAPU_IMPLEMENTATION

--- a/main.c
+++ b/main.c
@@ -87,6 +87,10 @@ int main()
     PRINT_ISA_SUPPORT(d)
     PRINT_ISA_SUPPORT(c)
 
+#elif __loongarch__
+    PRINT_ISA_SUPPORT(lsx)
+    PRINT_ISA_SUPPORT(lasx)
+
 #endif
 
     return 0;

--- a/ruapu.h
+++ b/ruapu.h
@@ -136,7 +136,7 @@ static int ruapu_detect_isa(ruapu_some_inst some_inst)
 
 #if defined(__i386__) || defined(__x86_64__) || __s390x__
 #define RUAPU_INSTCODE(isa, ...) static void ruapu_some_##isa() { asm volatile(".byte " #__VA_ARGS__ : : : ); }
-#elif __aarch64__ || __arm__ || __mips__ || __riscv
+#elif __aarch64__ || __arm__ || __mips__ || __riscv || __loongarch__
 #define RUAPU_INSTCODE(isa, ...) static void ruapu_some_##isa() { asm volatile(".word " #__VA_ARGS__ : : : ); }
 #elif __powerpc__
 #define RUAPU_INSTCODE(isa, ...) static void ruapu_some_##isa() { asm volatile(".long " #__VA_ARGS__ : : : ); }
@@ -240,6 +240,10 @@ RUAPU_INSTCODE(f, 0x10a57553) // fmul.s fa0,fa0,fa0
 RUAPU_INSTCODE(d, 0x12a57553) // fmul.d fa0,fa0,fa0
 RUAPU_INSTCODE(c, 0x0001952a) // add a0,a0,a0 + nop
 
+#elif __loongarch__
+RUAPU_INSTCODE(lsx, 0x700b0000) //vadd.w vr0, vr0, vr0
+RUAPU_INSTCODE(lasx, 0x740b0000) //xvadd.w xr0, xr0, xr0
+
 #endif
 
 #undef RUAPU_INSTCODE
@@ -319,6 +323,10 @@ RUAPU_ISAENTRY(a)
 RUAPU_ISAENTRY(f)
 RUAPU_ISAENTRY(d)
 RUAPU_ISAENTRY(c)
+
+#elif __loongarch__
+RUAPU_ISAENTRY(lsx)
+RUAPU_ISAENTRY(lasx)
 
 #endif
 };


### PR DESCRIPTION
test info:
```
junchao@arch6k ~/work/ruapu                                                                                                                                                        [14:58:16] 
> $lscpu                                                                                                                                                                           [±master]
Architecture:          loongarch64
  CPU op-mode(s):      32-bit, 64-bit
  Address sizes:       48 bits physical, 48 bits virtual
  Byte Order:          Little Endian
CPU(s):                8
  On-line CPU(s) list: 0-7
Model name:            Loongson-3A6000
  CPU family:          Loongson-64bit
  Model:               0x00
  Thread(s) per core:  1
  Core(s) per socket:  8
  Socket(s):           1
  BogoMIPS:            5000.00
  Flags:               cpucfg lam ual fpu lsx lasx crc32 complex crypto lvz lbt_x86 lbt_arm lbt_mips
Caches (sum of all):   
  L1d:                 512 KiB (8 instances)
  L1i:                 512 KiB (8 instances)
  L2:                  2 MiB (8 instances)
  L3:                  16 MiB (1 instance)
NUMA:                  
  NUMA node(s):        1
  NUMA node0 CPU(s):   0-7

junchao@arch6k ~/work/ruapu                                                                                                                                                        [14:52:36] 
> $ gcc main.c -o ruapu                                                                                                                                                            [±master]
                                                                                                                                                                                              
junchao@arch6k ~/work/ruapu                                                                                                                                                        [14:52:39] 
> $./ruapu                                                                                                                                                                         [±master]
lsx = 1
lasx = 1

```