### PR TITLE
Support more risc-v extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ _`fma4` on zen1, ISA in hypervisor, etc._
 |powerpc|`vsx`|
 |s390x|`zvector`|
 |loongarch|`lsx` `lasx`|
-|risc-v|`i` `m` `a` `f` `d` `c`|
+|risc-v|`i` `m` `a` `f` `d` `c` `zfa` `zfh` `zfhmin` `zicsr` `zifencei` |
 
 ## Techniques inside ruapu
 ruapu is implemented in C language to ensure the widest possible portability.

--- a/main.c
+++ b/main.c
@@ -86,6 +86,11 @@ int main()
     PRINT_ISA_SUPPORT(f)
     PRINT_ISA_SUPPORT(d)
     PRINT_ISA_SUPPORT(c)
+    PRINT_ISA_SUPPORT(zfa)
+    PRINT_ISA_SUPPORT(zfh)
+    PRINT_ISA_SUPPORT(zfhmin)
+    PRINT_ISA_SUPPORT(zicsr)
+    PRINT_ISA_SUPPORT(zifencei)
 
 #elif __loongarch__
     PRINT_ISA_SUPPORT(lsx)

--- a/ruapu.h
+++ b/ruapu.h
@@ -239,6 +239,11 @@ RUAPU_INSTCODE(a, 0x100122af, 0x185122af) // lr.w t0,(sp) + sc.w t0,t0,(sp)
 RUAPU_INSTCODE(f, 0x10a57553) // fmul.s fa0,fa0,fa0
 RUAPU_INSTCODE(d, 0x12a57553) // fmul.d fa0,fa0,fa0
 RUAPU_INSTCODE(c, 0x0001952a) // add a0,a0,a0 + nop
+RUAPU_INSTCODE(zfa, 0xf0108053) // fli.s ft0, min
+RUAPU_INSTCODE(zfh, 0x04007053); // fadd.hs ft0, ft0, ft0
+RUAPU_INSTCODE(zfhmin, 0xe4000553) // fmv.x.h a0, ft0
+RUAPU_INSTCODE(zicsr, 0xc0102573); // csrr a0, time
+RUAPU_INSTCODE(zifencei, 0x0000100f); // fence.i
 
 #elif __loongarch__
 RUAPU_INSTCODE(lsx, 0x700b0000) //vadd.w vr0, vr0, vr0
@@ -323,6 +328,11 @@ RUAPU_ISAENTRY(a)
 RUAPU_ISAENTRY(f)
 RUAPU_ISAENTRY(d)
 RUAPU_ISAENTRY(c)
+RUAPU_ISAENTRY(zfa)
+RUAPU_ISAENTRY(zfh)
+RUAPU_ISAENTRY(zfhmin)
+RUAPU_ISAENTRY(zicsr)
+RUAPU_ISAENTRY(zifencei)
 
 #elif __loongarch__
 RUAPU_ISAENTRY(lsx)


### PR DESCRIPTION
Add support for zfa, zfh, zfhmin, zicsr and zifencei

tested on qemu-user version 8.2.1

```
$ qemu-riscv64 ./test
i = 1
m = 1
a = 1
f = 1
d = 1
c = 1
zfa = 1
zfh = 1
zfhmin = 1
zicsr = 1
zifencei = 1
```