### PR TITLE
Add warning when compiling UWP apps

### DIFF
--- a/ruapu.h
+++ b/ruapu.h
@@ -25,9 +25,14 @@ int ruapu_supports(const char* isa);
 #include <windows.h>
 
 #if WINAPI_FAMILY == WINAPI_FAMILY_APP
+// uwp does not support veh  :(
+#if defined (_MSC_VER)
+#pragma message("warning: ruapu does not support UWP yet.")
+#else
+#warning ruapu does not support UWP yet.
+#endif
 static int ruapu_detect_isa(const void* some_inst)
 {
-    // uwp does not support seh  :(
     (void)some_inst;
     return 0;
 }


### PR DESCRIPTION
(which is not supported for now...)

*BTW, `AddVectoredExceptionHandler` belongs to VEH (**V**ectored **E**xception **H**andling) mechanism, which is sometimes used in conjunction with SEH, but not SEH*