### PR TITLE
Fix RISCV M check

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ _`fma4` on zen1, ISA in hypervisor, etc._
 |powerpc|`vsx`|
 |s390x|`zvector`|
 |loongarch|`lsx` `lasx`|
-|risc-v|`i` `m` `a` `f` `d` `c` `zfa` `zfh` `zfhmin` `zicsr` `zifencei` |
+|risc-v|`i` `m` `a` `f` `d` `c` `zfa` `zfh` `zfhmin` `zicsr` `zifencei` `zmmul` |
 
 ## Techniques inside ruapu
 ruapu is implemented in C language to ensure the widest possible portability.

--- a/ruapu.h
+++ b/ruapu.h
@@ -247,7 +247,7 @@ RUAPU_INSTCODE(lasx, 0x740b0000) //xvadd.w xr0, xr0, xr0
 
 #elif __riscv
 RUAPU_INSTCODE(i, 0x00a50533) // add a0,a0,a0
-RUAPU_INSTCODE(m, 0x02a50533) // mul a0,a0,a0
+RUAPU_INSTCODE(m, 0x00200513, 0x02a50533, 0x02a54533) // addi a0,x0,2 mul a0,a0,a0 div a0,a0,a0
 RUAPU_INSTCODE(a, 0x100122af, 0x185122af) // lr.w t0,(sp) + sc.w t0,t0,(sp)
 RUAPU_INSTCODE(f, 0x10a57553) // fmul.s fa0,fa0,fa0
 RUAPU_INSTCODE(d, 0x12a57553) // fmul.d fa0,fa0,fa0
@@ -257,6 +257,7 @@ RUAPU_INSTCODE(zfh, 0x04007053); // fadd.hs ft0, ft0, ft0
 RUAPU_INSTCODE(zfhmin, 0xe4000553) // fmv.x.h a0, ft0
 RUAPU_INSTCODE(zicsr, 0xc0102573); // csrr a0, time
 RUAPU_INSTCODE(zifencei, 0x0000100f); // fence.i
+RUAPU_INSTCODE(zmmul, 0x02a50533) // mul a0,a0,a0
 
 #endif
 

--- a/ruapu.h
+++ b/ruapu.h
@@ -350,6 +350,7 @@ RUAPU_ISAENTRY(zfh)
 RUAPU_ISAENTRY(zfhmin)
 RUAPU_ISAENTRY(zicsr)
 RUAPU_ISAENTRY(zifencei)
+RUAPU_ISAENTRY(zmmul)
 
 #endif
 };


### PR DESCRIPTION
RISCV M扩展需要同时支持mul和div相关指令
只实现了mul的是zmmul(很少见)