### PR TITLE
Add lua binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,35 @@ fn main() {
 </td></tr>
 </table>
 
+### ruapu with Lua
+
+<table>
+
+<tr><td>
+
+Compile ruapu library
+
+```shell
+# from source code
+cd lua
+# lua binding has been tested on Lua 5.2~5.4
+luarocks make
+```
+</td>
+<td>
+
+Use ruapu in Lua
+
+```Lua
+ruapu = require "ruapu";
+print(ruapu.supports("mmx"));
+for _, ext in ipairs(ruapu.rua()) do
+    print(ext);
+end
+```
+</td></tr>
+</table>
+
 <details>
 <summary>Github-hosted runner result (Linux)</summary>
 

--- a/lua/ruapu-0.1-1.rockspec
+++ b/lua/ruapu-0.1-1.rockspec
@@ -1,0 +1,19 @@
+package = "ruapu"
+version = "0.1-1"
+source = {
+    url = "https://github.com/nihui/ruapu.git"
+}
+description = {
+    summary = "Detect CPU ISA features with single-file",
+    homepage = "https://github.com/nihui/ruapu",
+    license = "MIT"
+}
+dependencies = {
+    "lua >= 5.2, <= 5.4"
+}
+build = {
+    type = "builtin",
+    modules = {
+        ruapu = "ruapu-binding.c"
+    }
+}

--- a/lua/ruapu-binding.c
+++ b/lua/ruapu-binding.c
@@ -1,0 +1,36 @@
+#include<lua.h>
+#include<lauxlib.h>
+
+#define RUAPU_IMPLEMENTATION
+#include"../ruapu.h"
+
+static int supports(lua_State *l)
+{
+    luaL_checktype(l, 1, LUA_TSTRING);
+    lua_pushboolean(l, ruapu_supports(luaL_checkstring(l, 1)));
+    return 1;
+}
+
+static int rua(lua_State *l)
+{
+    const char * const *s = ruapu_rua();
+    lua_newtable(l);
+    for (int i = 0; s[i]; i++) {
+        lua_pushstring(l, s[i]);
+        lua_rawseti(l, -2, i + 1);
+    }
+    return 1;
+}
+
+static const struct luaL_Reg modRuapu[] = {
+    { "supports", supports },
+    { "rua", rua },
+    { NULL, NULL }
+};
+
+int luaopen_ruapu(lua_State *l)
+{
+    ruapu_init();
+    luaL_newlib(l, modRuapu);
+    return 1;
+}


### PR DESCRIPTION
This adds Lua binding for ruapu, has been tested on amd64 AlpineLinux with Lua 5.2 to Lua 5.4.

I am not sure the binding is valuable enough to get into the main repository, so I will maintain a separate repository if you think it is not.

The output of example added in README is like
```
$ lua5.4 test.lua
true
mmx
sse
sse2
sse3
ssse3
sse41
sse42
avx
f16c
fma
avx2
```