### PR TITLE
updated erlang binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,10 @@ end
 
 Compile ruapu library
 
-```shell
-# from source code
-rebar3 compile
+```erlang
+% add this to deps list 
+% in your rebar.config
+{ruapu, "0.1.0"}
 ```
 </td>
 <td>

--- a/erlang/.gitignore
+++ b/erlang/.gitignore
@@ -20,3 +20,4 @@ rebar3.crashdump
 doc/
 priv/
 _build/
+c_src/ruapu.h

--- a/erlang/CMakeLists.txt
+++ b/erlang/CMakeLists.txt
@@ -45,7 +45,6 @@ set(SOURCE_FILES
 if(POLICY CMP0068)
     cmake_policy(SET CMP0068 NEW)
 endif()
-include_directories("${ERTS_INCLUDE_DIR}")
 
 add_library(ruapu_nif SHARED
     ${SOURCE_FILES}
@@ -63,6 +62,11 @@ set_target_properties(ruapu_nif PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE
     BUILD_WITH_INSTALL_RPATH TRUE
 )
+if(EXISTS "${C_SRC}/ruapu.h")
+    target_include_directories(ruapu_nif PUBLIC "${ERTS_INCLUDE_DIR}")
+else()
+    target_include_directories(ruapu_nif PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/.." "${ERTS_INCLUDE_DIR}")
+endif()
 
 if(UNIX AND NOT APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-but-set-variable -Wno-reorder")

--- a/erlang/README.md
+++ b/erlang/README.md
@@ -1,0 +1,52 @@
+# ruapu erlang binding
+
+[![Hex pm](https://img.shields.io/hexpm/v/ruapu.svg)](https://hex.pm/packages/ruapu)
+[![Docs](https://img.shields.io/badge/hex-docs-green.svg?style=flat)](https://hexdocs.pm/ruapu)
+
+This is an Erlang/OTP binding for [ruapu](https://github.com/nihui/ruapu).
+
+## Installation
+
+To compile the module you simply run `rebar3 compile`.
+
+To run the unit tests run `rebar3 eunit`.
+
+To build the documentation run `rebar edoc`.
+
+To use ruapu in your project you can just add it as a dependency in your rebar.config file in the following way:
+
+```erlang
+{deps, [
+  {ruapu, "0.1.0"}
+]}
+```
+
+### Usage
+
+The getopt module provides two functions:
+
+```erlang
+ruapu:supports(ISA :: string() | atom() | binary()) -> boolean().
+
+ruapu:rua() -> {ok, [string()]} | {error, string()}.
+```
+
+For example:
+
+```erlang
+% pass the ISA as a string, atom or binary
+1> ruapu:supports("neon").
+true
+2> ruapu:supports(neon).
+true
+3> ruapu:supports(<<"neon">>).
+true
+% get all supported ISAs
+4> ruapu:rua().
+{ok,["neon","vfpv4","asimdrdm","asimdhp","asimddp",
+     "asimdfhm","bf16","i8mm","pmull","crc32","aes","sha1",
+     "sha2","sha3","sha512","amx"]}
+```
+
+### For developers
+To release a new version of the library, you need to use the `release.sh` script. It will copy the `ruapu.h` to the `c_src` directory so that it can included in the released package.

--- a/erlang/c_src/ruapu.c
+++ b/erlang/c_src/ruapu.c
@@ -2,7 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #define RUAPU_IMPLEMENTATION
-#include "../../ruapu.h"
+#include "ruapu.h"
 
 ERL_NIF_TERM atom(ErlNifEnv *env, const char *msg) {
   ERL_NIF_TERM a;

--- a/erlang/release.sh
+++ b/erlang/release.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+cp -f ../ruapu.h ./c_src/
+rebar3 hex publish
+rm -f ./c_src/ruapu.h


### PR DESCRIPTION
This PR updated Erlang binding so that it can be released to hex.pm with necessary files included. And the Erlang binding is now available on hex.pm, https://hex.pm/packages/ruapu.