### PR TITLE
Fix zbb/zbkb detection

### DIFF
--- a/ruapu.h
+++ b/ruapu.h
@@ -308,10 +308,10 @@ RUAPU_INSTCODE(f, 0x10a57553) // fmul.s fa0,fa0,fa0
 RUAPU_INSTCODE(d, 0x12a57553) // fmul.d fa0,fa0,fa0
 RUAPU_INSTCODE(c, 0x0001952a) // add a0,a0,a0 + nop
 RUAPU_INSTCODE(zba, 0x20a52533) // sh1add a0,a0,a0
-RUAPU_INSTCODE(zbb, 0x40a57533) // andn a0,a0,a0
+RUAPU_INSTCODE(zbb, 0x60451513) // sext.b a0,a0,a0
 RUAPU_INSTCODE(zbc, 0x0aa52533) // clmulr a0,a0,a0
 RUAPU_INSTCODE(zbs, 0x48a51533) // bclr a0,a0,a0
-RUAPU_INSTCODE(zbkb, 0x60a51533) // rol a0,a0,a0
+RUAPU_INSTCODE(zbkb, 0x08a54533) // pack a0,a0,a0
 RUAPU_INSTCODE(zbkc, 0x0aa53533) // clmulh a0,a0,a0
 RUAPU_INSTCODE(zbkx, 0x28a52533) // xperm.n a0,a0,a0
 RUAPU_INSTCODE(zfa, 0xf0108053) // fli.s ft0, min


### PR DESCRIPTION
This patch uses `sext.b` and `pack` to distinguish zbkb from zbb.
```
// llvm-mc -filetype=obj -triple=riscv64 -mattr=+zbb,+zbkb < tmp.S | llvm-objdump --mattr=+zbb,+zbkb -d -r -
add a0,a0,a0
sext.b a0,a0 # zbb
pack a0,a0,a0 # zbkb
```
```
<stdin>:        file format elf64-littleriscv

Disassembly of section .text:

0000000000000000 <.text>:
       0: 00a50533      add     a0, a0, a0
       4: 60451513      sext.b  a0, a0
       8: 08a54533      pack    a0, a0, a0
```

Tested with qemu:
```
riscv64-linux-gnu-gcc main.c
qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64,zbb=false,zbkb=false ./a.out
qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64,zbb=true,zbkb=false ./a.out
qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64,zbb=false,zbkb=true ./a.out
qemu-riscv64 -L /usr/riscv64-linux-gnu/ -cpu rv64,zbb=true,zbkb=true ./a.out
```

It addresses the issue that ruapu incorrectly reported that zbkb is available on Spacemit-K1.
See also https://github.com/llvm/llvm-project/pull/94564.
