### PR TITLE
Detect x86 AES-NI and SHA extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ _`fma4` on zen1, ISA in hypervisor, etc._
 
 |CPU|ISA|
 |:---:|---|
-|x86|`mmx` `sse` `sse2` `sse3` `ssse3` `sse41` `sse42` `sse4a` `xop` `avx` `f16c` `fma` `fma4` `avx2` `avx512f` `avx512bw` `avx512cd` `avx512dq` `avx512vl` `avx512vnni` `avx512bf16` `avx512ifma` `avx512vbmi` `avx512vbmi2` `avx512fp16` `avx512er` `avx5124fmaps` `avx5124vnniw` `avxvnni` `avxvnniint8` `avxvnniint16` `avxifma` `amxfp16` `amxbf16` `amxint8` `amxtile`|
+|x86|`mmx` `sse` `sse2` `sse3` `ssse3` `sse41` `sse42` `sse4a` `xop` `avx` `f16c` `fma` `fma4` `avx2` `avx512f` `avx512bw` `avx512cd` `avx512dq` `avx512vl` `avx512vnni` `avx512bf16` `avx512ifma` `avx512vbmi` `avx512vbmi2` `avx512fp16` `avx512er` `avx5124fmaps` `avx5124vnniw` `avxvnni` `avxvnniint8` `avxvnniint16` `avxifma` `amxfp16` `amxbf16` `amxint8` `amxtile` `aesni` `sha` |
 |arm|`half` `edsp` `neon` `vfpv4` `idiv`|
 |aarch64|`neon` `vfpv4` `lse` `cpuid` `asimdrdm` `asimdhp` `asimddp` `asimdfhm` `bf16` `i8mm` `frint` `jscvt` `fcma` `mte` `mte2` `sve` `sve2` `svebf16` `svei8mm` `svef32mm` `svef64mm` `sme` `smef16f16` `smef64f64` `smei64i64` `pmull` `crc32` `aes` `sha1` `sha2` `sha3` `sha512` `sm3` `sm4` `svepmull` `svebitperm` `sveaes` `svesha3` `svesm4` `amx`|
 |mips|`msa` `mmi` `sx` `asx` `msa2` `crypto`|

--- a/main.c
+++ b/main.c
@@ -52,6 +52,8 @@ int main()
     PRINT_ISA_SUPPORT(amxbf16)
     PRINT_ISA_SUPPORT(amxint8)
     PRINT_ISA_SUPPORT(amxtile)
+    PRINT_ISA_SUPPORT(aesni)
+    PRINT_ISA_SUPPORT(sha)
 
 #elif __aarch64__ || defined(_M_ARM64)
     PRINT_ISA_SUPPORT(neon)

--- a/ruapu.h
+++ b/ruapu.h
@@ -225,6 +225,8 @@ RUAPU_INSTCODE(amxfp16, 0xc4, 0xe2, 0x7b, 0x5c, 0xd1) // tdpfp16ps %tmm0, %tmm1,
 RUAPU_INSTCODE(amxbf16, 0xc4, 0xe2, 0x7a, 0x5c, 0xd1) // tdpbf16ps %tmm0, %tmm1, %tmm2
 RUAPU_INSTCODE(amxint8, 0xc4, 0xe2, 0x7b, 0x5e, 0xd1) // tdpbssd %tmm0, %tmm1, %tmm2
 RUAPU_INSTCODE(amxtile, 0xc4, 0xe2, 0x7a, 0x49, 0xc0) // tilezero %tmm0
+RUAPU_INSTCODE(aesni, 0x66, 0x0f, 0x38, 0xdc, 0xc0) // aesenc xmm0,xmm0
+RUAPU_INSTCODE(sha, 0x0f, 0x38, 0xc9, 0xc0) // sha1msg1 xmm0,xmm0
 
 #elif __aarch64__ || defined(_M_ARM64)
 RUAPU_INSTCODE(neon, 0x4e20d400) // fadd v0.4s,v0.4s,v0.4s
@@ -436,6 +438,8 @@ RUAPU_ISAENTRY(amxfp16)
 RUAPU_ISAENTRY(amxbf16)
 RUAPU_ISAENTRY(amxint8)
 RUAPU_ISAENTRY(amxtile)
+RUAPU_ISAENTRY(aesni)
+RUAPU_ISAENTRY(sha)
 
 #elif __aarch64__ || defined(_M_ARM64)
 RUAPU_ISAENTRY(neon)


### PR DESCRIPTION
Some Thinkpads disable AES-NI by default. This commit adds AES-NI and SHA support.