### PR TITLE
Replace FlyCI runners with GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,8 @@ jobs:
         docker run -u root --rm -v $(pwd):/${{ github.workspace }} -w ${{ github.workspace }} --platform linux/${{ matrix.arch }} debian:unstable-slim \
           /bin/bash -c "apt update && apt install -y gcc libc6-dev && gcc main.c -o ruapu && ./ruapu"
 
-  macos-flyci:
-    runs-on: flyci-macos-14-xlarge-m2
+  macos-latest:
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
     - name: build-test


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).