### PR TITLE
Fix DLL unloading crash on Windows

### DIFF
--- a/ruapu.h
+++ b/ruapu.h
@@ -25,9 +25,7 @@ const char* const* ruapu_rua();
 typedef void (*ruapu_some_inst)();
 
 #if defined _WIN32
-
 #include <windows.h>
-#include <setjmp.h>
 
 #if defined (_MSC_VER) // MSVC
 static int ruapu_detect_isa(ruapu_some_inst some_inst)
@@ -47,7 +45,10 @@ static int ruapu_detect_isa(ruapu_some_inst some_inst)
     return g_ruapu_sigill_caught ? 0 : 1;
 }
 #else
-static volatile int g_ruapu_sigill_caught = 0;
+#include <setjmp.h>
+#include <signal.h>
+
+static volatile sig_atomic_t g_ruapu_sigill_caught = 0;
 static jmp_buf g_ruapu_jmpbuf;
 
 static void ruapu_jump_back(void)
@@ -108,7 +109,7 @@ static int ruapu_detect_isa(ruapu_some_inst some_inst)
 #include <signal.h>
 #include <setjmp.h>
 
-static int g_ruapu_sig_caught = 0;
+static volatile sig_atomic_t g_ruapu_sig_caught = 0;
 static sigjmp_buf g_ruapu_jmpbuf;
 
 static void ruapu_catch_sig(int signo, siginfo_t* si, void* data)

--- a/ruapu.h
+++ b/ruapu.h
@@ -30,7 +30,7 @@ typedef void (*ruapu_some_inst)();
 #if defined (_MSC_VER) // MSVC
 static int ruapu_detect_isa(ruapu_some_inst some_inst)
 {
-    volatile int g_ruapu_sigill_caught = 0;
+    volatile int ruapu_sigill_caught = 0;
 
     __try
     {
@@ -39,10 +39,10 @@ static int ruapu_detect_isa(ruapu_some_inst some_inst)
     __except (GetExceptionCode() == EXCEPTION_ILLEGAL_INSTRUCTION ?
         EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
     {
-        g_ruapu_sigill_caught = 1;
+        ruapu_sigill_caught = 1;
     }
 
-    return g_ruapu_sigill_caught ? 0 : 1;
+    return ruapu_sigill_caught ? 0 : 1;
 }
 #else
 #include <setjmp.h>
@@ -70,13 +70,11 @@ static LONG CALLBACK ruapu_catch_sigill(PEXCEPTION_POINTERS ExceptionInfo)
 {
     if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION)
     {
-#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
-#ifdef _WIN64 // X64
+#if defined(__x86_64__) || defined(_M_X64) // X64
         ExceptionInfo->ContextRecord->Rip = (DWORD_PTR)ruapu_jump_back;
-#else // X86
+#elif defined(__i386__) || defined(_M_IX86) // X86
         ExceptionInfo->ContextRecord->Eip = (DWORD_PTR)ruapu_jump_back;
-#endif
-#else //ARM
+#else // ARM
         ExceptionInfo->ContextRecord->Pc = (DWORD_PTR)ruapu_jump_back;
 #endif
         g_ruapu_sigill_caught = 1;


### PR DESCRIPTION
在Windows平台上，除了MSVC和模仿MSVC以外的编译器目前使用向量化异常处理，并且在异常回调中用`longjump`直接跳出，这会导致跳过某些必要的帧栈操作以及清理操作，Windows异常子系统可能认为异常仍在处理中，系统维护的异常处理链未被正确解除，从而如果ruapu是在动态加载的DLL中运行的话，卸载时可能崩溃。

该PR通过一个中转函数来执行跳转，从而确保异常处理回调可以正确退出，完成清理操作，修复了崩溃。

**附加修改：**
*   **对于Go包装:** 由于Go注册了自己的向量化异常处理函数，所以需要再注册一个`VectoredContinueHandler`以防止错误被Go运行时二次捕获。

*   此PR还将`g_ruapu_sigill_caught`的定义改为`volatile int` （或者`volatile sig_atomic_t`，如果必要的话），以防止某些编译器将其优化掉。

----------

On Windows platforms, for compilers other than MSVC and those mimicking MSVC, vectorized exception handling (VEH) is currently used. During an exception callback, `longjmp` is employed to jump out directly. This bypasses certain necessary frame stack operations and cleanup routines. Consequently, the Windows exception subsystem may incorrectly believe the exception is still being processed, and the exception handling chain maintained by the system is not properly unwound. If ruapu is running within a dynamically loaded DLL, this can lead to crashes during unloading.

This PR addresses the crash by introducing a trampoline function to perform the jump. This ensures the exception handling callback exits correctly, allowing the necessary cleanup to complete.

**Additionally:**
*   **For the Go wrapper:** Since Go registers its own Vectored Exception Handler, this PR registers an additional `VectoredContinueHandler` to prevent the error from being re-caught by the Go runtime.
*   The definition of `g_ruapu_sigill_caught` is changed to `volatile int`  (or `volatile sig_atomic_t` if necessary) to prevent certain compilers from optimizing it away.